### PR TITLE
[ENG-7186]  update-danger-version

### DIFF
--- a/lib/sep/danger/version.rb
+++ b/lib/sep/danger/version.rb
@@ -1,5 +1,5 @@
 module Sep
   module Danger
-    VERSION = '0.2.11'
+    VERSION = '0.3.0'
   end
 end

--- a/sep-danger.gemspec
+++ b/sep-danger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'danger', '~> 4.2'
+  spec.add_runtime_dependency 'danger', '~> 8.4.5'
   spec.add_runtime_dependency 'danger-rubocop'
   spec.add_runtime_dependency 'danger-junit'
   spec.add_runtime_dependency 'danger-simplecov_json'


### PR DESCRIPTION
This is needed for AWS opensearch integration - since of connected dependency to the `faraday` gem version

https://welcome.atlassian.net/browse/ENG-7186

connected pr - elastic user search opensearch searchkick
